### PR TITLE
Greenkeeper: Ignore eslint-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,11 @@
   },
   "peerDependencies": {
     "hapi": "^16.0.0"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "eslint",
+      "eslint-plugin-import"
+    ]
   }
 }


### PR DESCRIPTION
Greenkeeper: Ignore eslint and eslint-plugin-import because they are peerDependencies of eslint-config-airbnb-base